### PR TITLE
added start.bat for windows users; updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ pip install --editable .
 ## Run Project
 ### To run
 ```
+# if running on mac or linux:
 ./start.sh
+
+# if running on windows:
+./start.bat
+
 ```
 In a separate terminal
 ```

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,10 @@
+@echo off
+
+REM Install dependencies in ./server_api
+pip install -r server_api\requirements.txt
+
+REM Start the API server
+start cmd /C "python server_api\main.py & pause"
+
+REM Start the Pytc-connectomics server
+start cmd /C "python server_pytc\main.py & pause"

--- a/start.bat
+++ b/start.bat
@@ -4,7 +4,7 @@ REM Install dependencies in ./server_api
 pip install -r server_api\requirements.txt
 
 REM Start the API server
-start cmd /C "python server_api\main.py & pause"
+start cmd /C "python server_api\main.py && pause"
 
 REM Start the Pytc-connectomics server
-start cmd /C "python server_pytc\main.py & pause"
+start cmd /C "python server_pytc\main.py && pause"


### PR DESCRIPTION
Hi, For the issue PYT-94, a new start.bat file was created for windows users. Previously, the start.sh file was using bash commands. and it starts the 2 servers without being able to keep them running. When the process move on to the next command, the server started earlier automatically closed down.  With this windows styled start.bat file, the 2 servers will both run in their own terminals and will remain on to serve the client.