### PR TITLE
remove need for samples_pytc folder

### DIFF
--- a/client/src/components/Dragger.js
+++ b/client/src/components/Dragger.js
@@ -120,7 +120,7 @@ function Dragger() {
   const handlePreview = async (file) => {
     setFileUID(file.uid);
     if (!file.url && !file.preview) {
-        if (file.type !== 'image/tiff') {
+        if (file.type !== "image/tiff" || file.type !== "image/tif") {
             if (file.path) { // Use the local path for Electron environment
                 const fs = window.require('fs');
                 const buffer = fs.readFileSync(file.path);
@@ -156,7 +156,7 @@ function Dragger() {
 
   const handleBeforeUpload = (file) => {
     // Create a URL for the thumbnail using object URL
-    if (file.type !== "image/tiff") {
+    if (file.type !== "image/tiff" || file.type !== "image/tif") {
       file.thumbUrl = URL.createObjectURL(file);
     } else {
       file.thumbUrl = DEFAULT_IMAGE;


### PR DESCRIPTION
- changes Dragger.js code such that file uploads no longer need to be in a specific folder; any directory on the user's machine works
- seemingly no bugs but should be tested before merge