### PR TITLE
patch for cross_over react-scripts build

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "CI=false react-scripts build",
+    "build": "cross-env CI=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "electron": "electron ."
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
+    "cross-env": "^7.0.3",
     "electron-reload": "^2.0.0-alpha.1",
     "prettier": "^3.3.2"
   },


### PR DESCRIPTION
- Add cross-env package, which provides a consistent way of setting environment variables across different operating systems. this was used to run `CI=false react-scripts build` on the client side