### PR TITLE
fixed unused variables and missing variables in dependency array repo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Alternatively, dependencies can be installed with native Python via. the followi
 ```bash
 # Create a venv
 python -m venv .venv
+# if running in windows, replace the line above with '.\.venv\Scripts\activate.bat'
 source .venv/bin/activate
 
 # Install dependencies
@@ -39,7 +40,8 @@ conda install pytorch torchvision
 
 # If installing via native python
 python -m venv .venv
-source .venv/bin/activate
+source .venv/bin/activate 
+# if running in windows, replace the line above with '.\.venv\Scripts\activate.bat'
 pip install torch torchvision
 ```
 
@@ -47,6 +49,13 @@ pip install torch torchvision
 ```bash
 cd client
 npm install
+#(for windows user, modify the file "pytc-client/client/package.json" before running "npm run build")
+#ATTENTION: modify "pytc-client/client/package.json", NOT "pytc-client/package.json"  
+#In package.json, change the line under the "scripts" key:
+#     "build": "CI=false react-scripts build",
+# to 
+#     "build": "react-scripts build",
+#Because windows doesn't recognize environment variable "CI"
 npm run build
 ```
 

--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "CI=false react-scripts build",
+    "build": "react-scripts build", 
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "electron": "electron ."

--- a/client/src/components/YamlFileEditor.js
+++ b/client/src/components/YamlFileEditor.js
@@ -18,7 +18,8 @@ const YamlFileEditor = (props) => {
       context.setInferenceConfig(updatedYamlContent);
     }
     try {
-      const yamlData = yaml.load(updatedYamlContent);
+      // const yamlData = yaml.load(updatedYamlContent);
+      yaml.load(updatedYamlContent);
 
       // YAMLContext.setNumGPUs(yamlData.SYSTEM.NUM_GPUS);
       // YAMLContext.setNumCPUs(yamlData.SYSTEM.NUM_CPUS);
@@ -33,7 +34,7 @@ const YamlFileEditor = (props) => {
       setYamlContent(context.trainingConfig);
     }
 
-    if (type == "inference") {
+    if (type === "inference") {
       setYamlContent(context.inferenceConfig);
     }
   }, [

--- a/client/src/components/YamlFileUploader.js
+++ b/client/src/components/YamlFileUploader.js
@@ -11,7 +11,7 @@ const YamlFileUploader = (props) => {
   const YAMLContext = useContext(YamlContext);
   const { type } = props;
 
-  const [yamlContent, setYamlContent] = useState("");
+  const [, setYamlContent] = useState("");
 
   const trainingParams = [
     {
@@ -250,7 +250,7 @@ const YamlFileUploader = (props) => {
       setYamlContent(context.trainingConfig);
     }
 
-    if (type == "inference") {
+    if (type === "inference") {
       setYamlContent(context.inferenceConfig);
     }
   }, [

--- a/client/src/contexts/GlobalContext.js
+++ b/client/src/contexts/GlobalContext.js
@@ -34,14 +34,14 @@ function usePersistedState(key, defaultValue) {
 }
 
 
-function safeParseJSON(jsonString, defaultValue) {
-  try {
-    return JSON.parse(jsonString) || defaultValue;
-  } catch (e) {
-    console.error("Error parsing JSON:", e);
-    return defaultValue;
-  }
-}
+// function safeParseJSON(jsonString, defaultValue) {
+//   try {
+//     return JSON.parse(jsonString) || defaultValue;
+//   } catch (e) {
+//     console.error("Error parsing JSON:", e);
+//     return defaultValue;
+//   }
+// }
 
 export const ContextWrapper = (props) => {
   const [files, setFiles] = usePersistedState("files", []);

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -54,7 +54,7 @@ export async function startModelTraining(
 
 export async function stopModelTraining() {
   try {
-    const res = await axios.post(
+    await axios.post(
       `${process.env.REACT_APP_API_PROTOCOL}://${process.env.REACT_APP_API_URL}/stop_model_training`
     );
     return;
@@ -101,7 +101,7 @@ export async function getTensorboardURL() {
 }
 
 export async function startModelInference(
-  configurationYamlFile,
+  // configurationYamlFile,
   inferenceConfig,
   outputPath,
   checkpointPath
@@ -133,7 +133,7 @@ export async function startModelInference(
 
 export async function stopModelInference() {
   try {
-    const res = await axios.post(
+    await axios.post(
       `${process.env.REACT_APP_API_PROTOCOL}://${process.env.REACT_APP_API_URL}/stop_model_inference`
     );
     return;

--- a/client/src/views/DataLoader.js
+++ b/client/src/views/DataLoader.js
@@ -36,17 +36,18 @@ function DataLoader(props) {
   const handleInputScales = (event) => {
     setScales(event.target.value);
   };
-
+  
+  const {files, setFileList} = context;
   useEffect(() => {
-    if (context.files) {
-      context.setFileList(
-        context.files.map((file) => ({
+    if (files) {
+      setFileList(
+        files.map((file) => ({
           label: file.name,
           value: file.uid,
         }))
       );
     }
-  }, [context.files]);
+  }, [files, setFileList]);
 
   return (
     <Space

--- a/client/src/views/ModelInference.js
+++ b/client/src/views/ModelInference.js
@@ -35,10 +35,11 @@ function ModelInference() {
     }
   };
 
-  const [componentSize, setComponentSize] = useState("default");
-  const onFormLayoutChange = ({ size }) => {
-    setComponentSize(size);
-  };
+  // const [componentSize, setComponentSize] = useState("default");
+  const [componentSize,] = useState("default");
+  // const onFormLayoutChange = ({ size }) => {
+  //   setComponentSize(size);
+  // };
 
   return (
     <>

--- a/client/src/views/ModelTraining.js
+++ b/client/src/views/ModelTraining.js
@@ -60,10 +60,10 @@ function ModelTraining() {
   //     console.log(e);
   //   }
   // };
-  const [componentSize, setComponentSize] = useState("default");
-  const onFormLayoutChange = ({ size }) => {
-    setComponentSize(size);
-  };
+  // const [componentSize, setComponentSize] = useState("default");
+  // const onFormLayoutChange = ({ size }) => {
+  //   setComponentSize(size);
+  // };
 
   return (
     <>

--- a/client/src/views/Monitoring.js
+++ b/client/src/views/Monitoring.js
@@ -18,7 +18,7 @@ function Monitoring() {
     if (!tensorboardURL) {
       callGetTensorboardURL();
     }
-  }, []);
+  }, [tensorboardURL]);
 
   return (
     <>

--- a/client/src/views/Views.js
+++ b/client/src/views/Views.js
@@ -55,7 +55,7 @@ function Views() {
           currentLabel,
           scales
         );
-        let newUrl = res.replace(/\/\/[^:\/]+/, "//localhost");
+        let newUrl = res.replace(/\/\/[^:/]+/, "//localhost");
         console.log("Viewer at ", newUrl);
 
         setViewers([

--- a/client/src/views/Visualization.js
+++ b/client/src/views/Visualization.js
@@ -57,6 +57,7 @@ function Visualization(props) {
             key: viewer.key,
             children: (
               <iframe
+                title="Viewer Display" 
                 width="100%"
                 height="800"
                 frameBorder="0"


### PR DESCRIPTION
Below is the ESlint response based on the "npm run build" output of 2024/06/20

[eslint] 
src\components\YamlFileEditor.js
  Line 21:13:  'yamlData' is assigned a value but never used  no-unused-vars
	Fix: Line 21:13: "// const yamlData = yaml.load(updatedYamlContent);" ==> "yaml.load(updatedYamlContent);"
  Line 36:14:  Expected '===' and instead saw '=='            eqeqeq
	Fix:     "if (type == "inference") {" ==> "    if (type === "inference") {"





src\components\YamlFileUploader.js
  Line 14:10:   'yamlContent' is assigned a value but never used  no-unused-vars
	Fix:     const [yamlContent, setYamlContent] = useState("");  ==>  const [, setYamlContent] = useState("");
  Line 253:14:  Expected '===' and instead saw '=='               eqeqeq
	Fix: "if (type == "inference")"    ==> "if (type === "inference")"

src\contexts\GlobalContext.js
  Line 37:10:  'safeParseJSON' is defined but never used  no-unused-vars
	Fix: commented lines 37 - 44

src\utils\api.js
  Line 57:11:   'res' is assigned a value but never used  no-unused-vars
	Fix:  "const res = await axios.post("   ==> "await axios.post("
  Line 136:11:  'res' is assigned a value but never used  no-unused-vars
	Fix: "const res = await axios.post("   ==> "await axios.post("
	
	Fix: Line 104:"configurationYamlFile," commented, as this variable is not used.

src\views\DataLoader.js
  Line 49:6:  React Hook useEffect has a missing dependency: 'context'. Either include it or remove the dependency array 
 react-hooks/exhaustive-deps
	Fix:   
"useEffect(() => {
    if (context.files) {
      context.setFileList(
        context.files.map((file) => ({
          label: file.name,
          value: file.uid,
        }))
      );
    }
  }, [context.files]);"
==>
"
  const {files, setFileList} = context;
  useEffect(() => {
    if (files) {
      setFileList(
        files.map((file) => ({
          label: file.name,
          value: file.uid,
        }))
      );
    }
  }, [files, setFileList]);
"

src\views\ModelInference.js
  Line 39:9:  'onFormLayoutChange' is assigned a value but never used  no-unused-vars
	Fix: commented lines 39-41


src\views\ModelTraining.js
  Line 63:10:  'componentSize' is assigned a value but never used       no-unused-vars
	Fix: "  // const [componentSize, setComponentSize] = useState("default");" commented out
  Line 64:9:   'onFormLayoutChange' is assigned a value but never used  no-unused-vars
	Fix: commented lines 64-66

src\views\Monitoring.js
  Line 21:6:  React Hook useEffect has a missing dependency: 'tensorboardURL'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
	Fix: added "tensorboardURL" to the dependency array

src\views\Views.js
  Line 58:42:  Unnecessary escape character: \/  no-useless-escape
	Fix: "let newUrl = res.replace(/\/\/[^:\/]+/, "//localhost");" ===> "let newUrl = res.replace(/\/\/[^:/]+/, "//localhost");"

src\views\Visualization.js
  Line 59:15:  <iframe> elements must have a unique title property  jsx-a11y/iframe-has-title
	Fix: added "title="Viewer Display" " to the prop list of <iframe>


[eslint] 
src\views\ModelInference.js
  Line 38:25:  'setComponentSize' is assigned a value but never used  no-unused-vars
	Fix: "const [componentSize, setComponentSize] = useState("default");" ===> "  const [componentSize,] = useState("default");"







Also, added a few more tips for windows users in the readme file:

source .venv/bin/activate 
# if running in windows, replace the line above with '.\.venv\Scripts\activate.bat'


#(for windows user, modify the file "pytc-client/client/package.json" before running "npm run build")
#ATTENTION: modify "pytc-client/client/package.json", NOT "pytc-client/package.json"  
#In package.json, change the line under the "scripts" key:
#     "build": "CI=false react-scripts build",
# to 
#     "build": "react-scripts build",
#Because windows doesn't recognize environment variable "CI"