### PR TITLE
commented out unused function 

### DIFF
--- a/client/src/components/Dragger.js
+++ b/client/src/components/Dragger.js
@@ -11,13 +11,13 @@ const path = require('path')
 export function Dragger () {
   const context = useContext(AppContext)
 
-  const getBase64 = (file) =>
-    new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.readAsDataURL(file)
-      reader.onload = () => resolve(reader.result)
-      reader.onerror = (error) => reject(error)
-    })
+  // const getBase64 = (file) =>
+  //   new Promise((resolve, reject) => {
+  //     const reader = new FileReader()
+  //     reader.readAsDataURL(file)
+  //     reader.onload = () => resolve(reader.result)
+  //     reader.onerror = (error) => reject(error)
+  //   })
 
   const onChange = (info) => {
     const { status } = info.file


### PR DESCRIPTION
commented out unused function "getBase64" in "src\components\Dragger.js" to avoid ESlint complaint.