### PR TITLE
fixed inference disruption problem

### DIFF
--- a/client/src/views/ModelInference.js
+++ b/client/src/views/ModelInference.js
@@ -5,7 +5,7 @@ import { startModelInference, stopModelInference } from '../utils/api'
 import Configurator from '../components/Configurator'
 import { AppContext } from '../contexts/GlobalContext'
 
-function ModelInference ({isInferring, setIsInferring}) {
+function ModelInference ({ isInferring, setIsInferring }) {
   const context = useContext(AppContext)
   // const [isInference, setIsInference] = useState(false)
   const handleStartButton = async () => {

--- a/client/src/views/ModelInference.js
+++ b/client/src/views/ModelInference.js
@@ -5,14 +5,15 @@ import { startModelInference, stopModelInference } from '../utils/api'
 import Configurator from '../components/Configurator'
 import { AppContext } from '../contexts/GlobalContext'
 
-function ModelInference () {
+function ModelInference ({isInferring, setIsInferring}) {
   const context = useContext(AppContext)
-  const [isInference, setIsInference] = useState(false)
+  // const [isInference, setIsInference] = useState(false)
   const handleStartButton = async () => {
     try {
       const inferenceConfig = localStorage.getItem('inferenceConfig')
 
-      const res = startModelInference(
+      // const res = startModelInference(
+      const res = await startModelInference(
         context.uploadedYamlFile.name,
         inferenceConfig,
         context.outputPath,
@@ -22,17 +23,19 @@ function ModelInference () {
     } catch (e) {
       console.log(e)
     } finally {
-      setIsInference(true)
+      // setIsInference(true)
+      setIsInferring(true)
     }
   }
 
   const handleStopButton = async () => {
     try {
-      stopModelInference()
+      await stopModelInference()
     } catch (e) {
       console.log(e)
     } finally {
-      setIsInference(false)
+      // setIsInference(false)
+      setIsInferring(false)
     }
   }
 
@@ -49,13 +52,13 @@ function ModelInference () {
         <Space wrap style={{ marginTop: 12 }} size={componentSize}>
           <Button
             onClick={handleStartButton}
-            disabled={isInference} // Disables the button when inference is running
+            disabled={isInferring} // Disables the button when inference is running
           >
             Start Inference
           </Button>
           <Button
             onClick={handleStopButton}
-            disabled={!isInference} // Disables the button when inference is not running
+            disabled={!isInferring} // Disables the button when inference is not running
           >
             Stop Inference
           </Button>

--- a/client/src/views/Views.js
+++ b/client/src/views/Views.js
@@ -35,7 +35,7 @@ function Views () {
     } else if (current === 'monitoring') {
       return <Monitoring />
     } else if (current === 'inference') {
-      return <ModelInference isInferring={isInferring} setIsInferring={setIsInferring  }/>
+      return <ModelInference isInferring={isInferring} setIsInferring={setIsInferring} />
     }
   }
 
@@ -81,8 +81,9 @@ function Views () {
     }
   }
 
-  useEffect(() => {//This function makes sure that the inferring will continue when current tab changes
+  useEffect(() => { // This function makes sure that the inferring will continue when current tab changes
     if (current === 'inference' && isInferring) {
+      console.log('Inference process is continuing...')
     }
   }, [current, isInferring])
 

--- a/client/src/views/Views.js
+++ b/client/src/views/Views.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import DataLoader from './DataLoader'
 import Visualization from '../views/Visualization'
 import ModelTraining from '../views/ModelTraining'
@@ -13,6 +13,7 @@ function Views () {
   const [current, setCurrent] = useState('visualization')
   const [viewers, setViewers] = useState([])
   const [isLoading, setIsLoading] = useState(false)
+  const [isInferring, setIsInferring] = useState(false)
   console.log(viewers)
 
   const onClick = (e) => {
@@ -34,7 +35,7 @@ function Views () {
     } else if (current === 'monitoring') {
       return <Monitoring />
     } else if (current === 'inference') {
-      return <ModelInference />
+      return <ModelInference isInferring={isInferring} setIsInferring={setIsInferring  }/>
     }
   }
 
@@ -79,6 +80,11 @@ function Views () {
       setIsLoading(false)
     }
   }
+
+  useEffect(() => {//This function makes sure that the inferring will continue when current tab changes
+    if (current === 'inference' && isInferring) {
+    }
+  }, [current, isInferring])
 
   return (
     <Layout


### PR DESCRIPTION
Originally, the default value of "isInference" is 'false'. Whenever the <ModelInference> component is rendered, the value of "isInference" is automatically set to false. So it appeared that when we switch out from and then back to "inference" tab, the "start inference" button is activated, as if the inference stopped. 
In this update, the variable pair { isInference, setIsInference} is replaced by a new pair { isInferring, setIsInferring }. And they became the prop of the component <ModelInference>. The value of "isInferring" is updated solely by "setIsInferring", not by any initializing default value. By this, the status of the "start inference" button is solely determined by the status of inferring. 