### PR TITLE
Fix overlapping workflow option buttons

### DIFF
--- a/client/src/components/WorkflowSelector.js
+++ b/client/src/components/WorkflowSelector.js
@@ -78,7 +78,6 @@ const WorkflowSelector = ({ visible, onSelect, onCancel, isManual }) => {
                 border: '1px solid #d9d9d9',
                 borderRadius: '4px',
                 padding: '12px',
-                height: '100%',
                 display: 'flex',
                 alignItems: 'center',
                 backgroundColor: selectedModes.includes(opt.value) ? '#e6f7ff' : 'transparent',


### PR DESCRIPTION
Tiny fix. Just removed height = 100% to fix overlap on workflow options buttons

Before:
<img width="1192" height="738" alt="Screenshot 2026-01-25 at 3 42 30 PM" src="https://github.com/user-attachments/assets/c7b61e70-cd88-489a-8685-f5756bd7c5ed" />

After:
<img width="1193" height="708" alt="Screenshot 2026-01-25 at 3 42 45 PM" src="https://github.com/user-attachments/assets/180254ed-f22d-4357-8f19-e5dc846d604d" />
