### PR TITLE
Use latest node version in app build workflow

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: 'lts/*'
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
All "Client App Build and Test" workflows have been failing. I believe it's because we're using an earlier version of node. Need to merge this into main to see if it fixes the issue.